### PR TITLE
fix: use local baseline in peak boundary refinement

### DIFF
--- a/R/step_sec_peaks_refine.R
+++ b/R/step_sec_peaks_refine.R
@@ -276,13 +276,16 @@ required_pkgs.step_sec_peaks_refine <- function(x, ...) {
 
 #' Refine peak boundaries using height fraction method
 #'
-#' For each peak, walks inward from the current boundaries until the signal
-#' exceeds `cutoff * apex_height`. Preserves original boundaries as
-#' `original_left_base` and `original_right_base`.
+#' For each peak, subtracts a local linear baseline (interpolated between the
+#' signal values at the left and right boundaries), then walks inward until
+#' the corrected signal exceeds `cutoff * apex_height`. This makes the step
+#' robust whether or not a global baseline correction has been applied.
+#' Preserves original boundaries as `original_left_base` and
+#' `original_right_base`.
 #'
 #' @param peaks A `peaks_tbl` from peak detection.
 #' @param location Numeric vector of x-axis values (elution volume).
-#' @param value Numeric vector of y-axis values (baseline-corrected signal).
+#' @param value Numeric vector of y-axis values (raw or baseline-corrected).
 #' @param cutoff Fraction of apex height for boundary threshold.
 #'
 #' @return Modified `peaks_tbl` with refined boundaries and original boundary
@@ -305,16 +308,34 @@ required_pkgs.step_sec_peaks_refine <- function(x, ...) {
 		region_values <- value[in_region]
 		region_locations <- location[in_region]
 
-		# Find apex height within this region
-		apex_height <- max(region_values, na.rm = TRUE)
+		# Subtract local baseline so the cutoff works on corrected signal.
+		# Without this, a non-zero baseline (e.g., -20 mV) inflates the apex
+		# height and shifts the threshold, producing boundaries that are far
+		# too tight. Linear interpolation between boundary values is a robust
+		# local estimate that works whether or not step_sec_baseline() was run.
+		# When the signal is already baseline-corrected, boundary values are
+		# near zero and this is effectively a no-op.
+		left_val <- region_values[1]
+		right_val <- region_values[length(region_values)]
+		span <- region_locations[length(region_locations)] - region_locations[1]
+		if (span > 0) {
+			local_baseline <- left_val + (right_val - left_val) *
+				(region_locations - region_locations[1]) / span
+		} else {
+			local_baseline <- rep(left_val, length(region_locations))
+		}
+		corrected <- region_values - local_baseline
+
+		# Find apex height above local baseline
+		apex_height <- max(corrected, na.rm = TRUE)
 
 		# Skip if apex height is non-positive
 		if (is.na(apex_height) || apex_height <= 0) next
 
 		threshold <- cutoff * apex_height
 
-		# Find points above threshold
-		above <- region_values >= threshold
+		# Find points above threshold (using corrected signal)
+		above <- corrected >= threshold
 		if (!any(above)) next
 
 		# Walk inward from left: first point >= threshold

--- a/tests/testthat/test-step-peaks-refine.R
+++ b/tests/testthat/test-step-peaks-refine.R
@@ -290,46 +290,46 @@ test_that("higher cutoff produces tighter boundaries", {
 # -- Baseline robustness tests -------------------------------------------------
 
 test_that("step_sec_peaks_refine handles non-zero baseline correctly", {
-	skip_if_not_installed("measure")
+  skip_if_not_installed("measure")
 
-	# Simulate a peak on a -20 mV baseline (common in real SEC data)
-	time <- seq(10, 25, by = 0.05)
-	baseline <- -20
-	peak <- 160 * dnorm(time, mean = 16, sd = 1.0)
-	signal <- baseline + peak
+  # Simulate a peak on a -20 mV baseline (common in real SEC data)
+  time <- seq(10, 25, by = 0.05)
+  baseline <- -20
+  peak <- 160 * dnorm(time, mean = 16, sd = 1.0)
+  signal <- baseline + peak
 
-	test_data <- tibble::tibble(sample_id = "test")
-	test_data$ri <- measure::new_measure_list(
-		list(measure::new_measure_tbl(location = time, value = signal))
-	)
+  test_data <- tibble::tibble(sample_id = "test")
+  test_data$ri <- measure::new_measure_list(
+    list(measure::new_measure_tbl(location = time, value = signal))
+  )
 
-	peaks <- measure:::new_peaks_tbl(
-		peak_id = 1L,
-		location = 16.0,
-		height = max(peak),
-		left_base = 10.0,
-		right_base = 25.0,
-		area = NA_real_
-	)
-	test_data$.peaks <- measure:::new_peaks_list(list(peaks))
+  peaks <- measure:::new_peaks_tbl(
+    peak_id = 1L,
+    location = 16.0,
+    height = max(peak),
+    left_base = 10.0,
+    right_base = 25.0,
+    area = NA_real_
+  )
+  test_data$.peaks <- measure:::new_peaks_list(list(peaks))
 
-	rec <- recipes::recipe(~., data = test_data) |>
-		step_sec_peaks_refine(measures_col = "ri", cutoff = 0.005)
+  rec <- recipes::recipe(~., data = test_data) |>
+    step_sec_peaks_refine(measures_col = "ri", cutoff = 0.005)
 
-	result <- recipes::prep(rec) |>
-		recipes::bake(new_data = NULL)
+  result <- recipes::prep(rec) |>
+    recipes::bake(new_data = NULL)
 
-	peaks_out <- result$.peaks[[1]]
+  peaks_out <- result$.peaks[[1]]
 
-	# Boundaries should be tightened but still wide — the peak extends from
-	# ~12.5 to ~19.5 mL at 0.5% of apex height. Without local baseline
-	# correction, boundaries would be excessively tight (~14-18 mL).
-	peak_width <- peaks_out$right_base[1] - peaks_out$left_base[1]
-	expect_gt(peak_width, 5.0)
+  # Boundaries should be tightened but still wide — the peak extends from
+  # ~12.5 to ~19.5 mL at 0.5% of apex height. Without local baseline
+  # correction, boundaries would be excessively tight (~14-18 mL).
+  peak_width <- peaks_out$right_base[1] - peaks_out$left_base[1]
+  expect_gt(peak_width, 5.0)
 
-	# Boundaries should be symmetric around the apex (±~3 sd at 0.5%)
-	expect_lt(peaks_out$left_base[1], 14.0)
-	expect_gt(peaks_out$right_base[1], 18.0)
+  # Boundaries should be symmetric around the apex (±~3 sd at 0.5%)
+  expect_lt(peaks_out$left_base[1], 14.0)
+  expect_gt(peaks_out$right_base[1], 18.0)
 })
 
 # -- Edge case tests -----------------------------------------------------------

--- a/tests/testthat/test-step-peaks-refine.R
+++ b/tests/testthat/test-step-peaks-refine.R
@@ -287,6 +287,51 @@ test_that("higher cutoff produces tighter boundaries", {
 	expect_lte(peaks_tight$right_base[1], peaks_loose$right_base[1])
 })
 
+# -- Baseline robustness tests -------------------------------------------------
+
+test_that("step_sec_peaks_refine handles non-zero baseline correctly", {
+	skip_if_not_installed("measure")
+
+	# Simulate a peak on a -20 mV baseline (common in real SEC data)
+	time <- seq(10, 25, by = 0.05)
+	baseline <- -20
+	peak <- 160 * dnorm(time, mean = 16, sd = 1.0)
+	signal <- baseline + peak
+
+	test_data <- tibble::tibble(sample_id = "test")
+	test_data$ri <- measure::new_measure_list(
+		list(measure::new_measure_tbl(location = time, value = signal))
+	)
+
+	peaks <- measure:::new_peaks_tbl(
+		peak_id = 1L,
+		location = 16.0,
+		height = max(peak),
+		left_base = 10.0,
+		right_base = 25.0,
+		area = NA_real_
+	)
+	test_data$.peaks <- measure:::new_peaks_list(list(peaks))
+
+	rec <- recipes::recipe(~., data = test_data) |>
+		step_sec_peaks_refine(measures_col = "ri", cutoff = 0.005)
+
+	result <- recipes::prep(rec) |>
+		recipes::bake(new_data = NULL)
+
+	peaks_out <- result$.peaks[[1]]
+
+	# Boundaries should be tightened but still wide — the peak extends from
+	# ~12.5 to ~19.5 mL at 0.5% of apex height. Without local baseline
+	# correction, boundaries would be excessively tight (~14-18 mL).
+	peak_width <- peaks_out$right_base[1] - peaks_out$left_base[1]
+	expect_gt(peak_width, 5.0)
+
+	# Boundaries should be symmetric around the apex (±~3 sd at 0.5%)
+	expect_lt(peaks_out$left_base[1], 14.0)
+	expect_gt(peaks_out$right_base[1], 18.0)
+})
+
 # -- Edge case tests -----------------------------------------------------------
 
 test_that("step_sec_peaks_refine handles peak with negative apex", {


### PR DESCRIPTION
## Summary

- `step_sec_peaks_refine()` was computing the height fraction cutoff from the raw signal value, which includes the baseline offset. For chromatograms with a non-zero baseline (e.g., -20 mV), the threshold was relative to the raw apex rather than the peak height above baseline, producing boundaries that were far too tight.
- Now subtracts a local linear baseline (interpolated between signal values at the peak boundaries) before applying the cutoff. This is a no-op when signal is already baseline-corrected.
- Adds a division-by-zero guard for the degenerate case where all points share the same location.

## Test plan

- [x] All 42 existing tests pass (no regressions — existing tests use zero-baseline Gaussians)
- [x] New test validates correct behavior with -20 mV baseline offset: peak width >5 mL and boundaries extend past ±2 sd from apex
- [ ] Manual verification with real SEC batch data in the `sec` app

🤖 Generated with [Claude Code](https://claude.com/claude-code)